### PR TITLE
Typo Fixes #1

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,7 +5,7 @@ function formatChar(char) {
 }
 
 export function formatString(str) {
-    return str.replace(str, formatChar);
+    return str.replace(uppercase, formatChar);
 }
 
 export function processAttributes(attrs) {


### PR DESCRIPTION
I assume the original intention of the `processAttributes` function was to convert camelcase to hyphenated case?